### PR TITLE
[FIX/ADD] l10n_it_central_journal_reportlab

### DIFF
--- a/l10n_it_central_journal_reportlab/wizard/print_giornale.py
+++ b/l10n_it_central_journal_reportlab/wizard/print_giornale.py
@@ -133,28 +133,42 @@ class WizardGiornaleReportlab(models.TransientModel):
                 am.name AS move_name,
                 aa.code AS account_code,
                 aa.name AS account_name,
-                COALESCE(am.ref, '') AS name,
+                COALESCE(am.ref, '') AS ref,
+                first_aml.name AS first_move_line_name,
+                    -- This will hold the first aml.name
                 SUM(aml.debit) AS debit,
                 SUM(aml.credit) AS credit
             FROM
                 account_move_line aml
                 LEFT JOIN account_move am ON (am.id = aml.move_id)
                 LEFT JOIN account_account aa ON (aa.id = aml.account_id)
+                LEFT JOIN (
+                    SELECT DISTINCT ON (am.id, aa.id) aml.move_id,
+                        aml.account_id, aml.name
+                    FROM account_move_line aml
+                    LEFT JOIN account_move am ON am.id = aml.move_id
+                    LEFT JOIN account_account aa ON aa.id = aml.account_id
+                    ORDER BY am.id, aa.id, aml.date
+                        -- Modify the order to get the first aml.name by date
+                ) first_aml ON first_aml.move_id = aml.move_id
+                AND first_aml.account_id = aml.account_id
             WHERE
                 aml.date >= %(date_from)s
                 AND aml.date <= %(date_to)s
-                AND am.state in %(target_type)s
-                AND aml.journal_id in %(journal_ids)s
+                AND am.state IN %(target_type)s
+                AND aml.journal_id IN %(journal_ids)s
             GROUP BY
                 am.date,
                 am.name,
                 aa.code,
                 aa.name,
-                am.ref
+                am.ref,
+                first_aml.name -- Add the first_aml.name to the GROUP BY clause
             ORDER BY
                 am.date,
                 am.name,
-                aa.code
+                aa.code,
+                am.ref;
         """
         params = {
             "date_from": wizard.date_move_line_from,
@@ -347,7 +361,32 @@ class WizardGiornaleReportlab(models.TransientModel):
             date = Paragraph(format_date(self.env, line["date"]), style_name)
             move = Paragraph(line["move_name"], style_name)
             account = Paragraph(account_name, style_name)
-            name = Paragraph(line["name"], style_name)
+            name = ""
+            account_id = self.env["account.account"].search(
+                [
+                    ("code", "=", line["account_code"]),
+                    ("name", "=", line["account_name"]),
+                ]
+            )
+            if account_id.account_type in [
+                "asset_receivable",
+                "liability_payable",
+            ]:
+                move_id = self.env["account.move"].search(
+                    [
+                        ("name", "=", line["move_name"]),
+                        ("date", "=", line["date"]),
+                    ]
+                )
+                if move_id.partner_id:
+                    name = Paragraph(str(move_id.partner_id.name or ""), style_name)
+            if not name:
+                name = (
+                    Paragraph(line["first_move_line_name"], style_name)
+                    if line["first_move_line_name"]
+                    else Paragraph("", style_name)
+                )
+            ref = Paragraph(line["ref"], style_name)
             # dato che nel SQL ho la somma dei crediti e debiti potrei avere
             # che un conto ha sia debito che credito
             lines_data = []
@@ -355,12 +394,16 @@ class WizardGiornaleReportlab(models.TransientModel):
                 debit = Paragraph(formatLang(self.env, line["debit"]), style_number)
                 credit = Paragraph(formatLang(self.env, 0), style_number)
                 list_balance.append((line["debit"], 0))
-                lines_data.append([[row, date, move, account, name, debit, credit]])
+                lines_data.append(
+                    [[row, date, ref, move, account, name, debit, credit]]
+                )
             if line["credit"] > 0:
                 debit = Paragraph(formatLang(self.env, 0), style_number)
                 credit = Paragraph(formatLang(self.env, line["credit"]), style_number)
                 list_balance.append((0, line["credit"]))
-                lines_data.append([[row, date, move, account, name, debit, credit]])
+                lines_data.append(
+                    [[row, date, ref, move, account, name, debit, credit]]
+                )
             for line_data in lines_data:
                 if previous_move_name != line["move_name"]:
                     previous_move_name = line["move_name"]


### PR DESCRIPTION
-fixed grouped formatting (moved values under correct columns, shifted to the right) 
-moved content of column "name" under "ref" (as it is the account_move ref) 
-inserted in column "name" value of field "name" of first account_move_line 
-if account type of grouped record of type "asset_receivable" or "liability_payable", column "name" shows partner name as in original (ungrouped) logic